### PR TITLE
CONBOT-14 Create KickUser Chat Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Provide a way to easily manage idle users by either messaging, moving, or kickin
 Allow the bot to assign roles to users who match certain criteria. More info TBD.
 
 ## Active Administration
-### Kick
-Remote and back-end support for kicking players from the server.
 ### Move
 Remote and back-end support for moving players between channels.
 ### Ban

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Syntax notes:
 
 ## Active Administration
 ### Kick
-Dual-side support for forced disconnects of connected clients.
-**Syntax:** !kick [clientId] [reason]
+Dual-side support for forced disconnects of connected clients.  
+**Syntax:** !kick [clientId] [reason]  
 **Use:** Kicks the client matching the clientId from the server with the provided reason.
 
 ## Communication Abilities

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 Interactive console application for TS3 server administration, featuring front-and-back-end operation of most aspects.
 
 # Current Features
+Syntax notes:
+- Any command with multiple syntaxes will allow any of those listed.
+- Parameters with [brackets] are required. Parameters with (parentheses) are optional.
+- Do not include the brackets or parentheses when calling the command.
+
+## Active Administration
+### Kick
+Dual-side support for forced disconnects of connected clients.
+**Syntax:** !kick [clientId] [reason]
+**Use:** Kicks the client matching the clientId from the server with the provided reason.
+
 ## Communication Abilities
 ### Ping/Pong
 Dual-side support for simple bot health-check by having it return a simple phrase when pinged.  

--- a/src/main/core/commands/Commands.java
+++ b/src/main/core/commands/Commands.java
@@ -3,6 +3,7 @@ package main.core.commands;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
+import main.core.commands.commands.KickCommand;
 import main.util.ErrorMessages;
 import main.core.commands.commands.PingCommand;
 import main.util.exception.CommandNotFoundException;
@@ -43,7 +44,7 @@ public class Commands {
     * @param event the contents of the message being checked.
     * @throws CommandNotFoundException if the command being referenced is not known.
     */
-   public static void handle(TextMessageEvent event) throws CommandNotFoundException {
+   public static void handle(TextMessageEvent event) throws CommandNotFoundException, Exception {
       validate(event.getMessage());
       String input = event.getMessage();
 
@@ -53,6 +54,9 @@ public class Commands {
       switch (action.toLowerCase()) {
          case "ping":
             new PingCommand(event);
+            return;
+         case "kick":
+            new KickCommand(event);
             return;
          default:
             throw (new CommandNotFoundException(command[0]));

--- a/src/main/core/commands/Commands.java
+++ b/src/main/core/commands/Commands.java
@@ -4,8 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
 import main.core.commands.commands.KickCommand;
-import main.util.ErrorMessages;
 import main.core.commands.commands.PingCommand;
+import main.util.ErrorMessages;
 import main.util.exception.CommandNotFoundException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
  * Core command handler class. In charge of routing commands to their correct handlers.
  */
 public class Commands {
+
    private static String prefix = "!";
 
    /**
@@ -28,6 +29,9 @@ public class Commands {
       final String action = command[0].substring(1);
 
       switch (action.toLowerCase()) {
+         case "kick":
+            new KickCommand(input);
+            return;
          case "ping":
             new PingCommand();
             return;
@@ -44,7 +48,7 @@ public class Commands {
     * @param event the contents of the message being checked.
     * @throws CommandNotFoundException if the command being referenced is not known.
     */
-   public static void handle(TextMessageEvent event) throws CommandNotFoundException, Exception {
+   public static void handle(TextMessageEvent event) throws CommandNotFoundException {
       validate(event.getMessage());
       String input = event.getMessage();
 
@@ -52,18 +56,20 @@ public class Commands {
       final String action = command[0].substring(1);
 
       switch (action.toLowerCase()) {
-         case "ping":
-            new PingCommand(event);
-            return;
          case "kick":
             new KickCommand(event);
+            return;
+         case "ping":
+            new PingCommand(event);
             return;
          default:
             throw (new CommandNotFoundException(command[0]));
       }
    }
 
-   /** Returns the prefix used to denote commands. */
+   /**
+    * Returns the prefix used to denote commands.
+    */
    public static String getPrefix() {
       return prefix;
    }

--- a/src/main/core/commands/commands/KickCommand.java
+++ b/src/main/core/commands/commands/KickCommand.java
@@ -2,46 +2,97 @@ package main.core.commands.commands;
 
 import com.github.theholywaffle.teamspeak3.TS3ApiAsync;
 import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
-import java.util.Objects;
+import java.util.logging.Level;
 import main.core.Executor;
+import main.server.ServerConnectionManager;
+import main.util.ErrorMessages;
 import main.util.MessageHandler;
+import main.util.exception.ArgumentMissingException;
+import main.util.exception.IllegalTargetException;
+import main.util.exception.InvalidUserIdException;
 
+/**
+ * Command used to forcefully disconnect a client from the server.
+ */
 public class KickCommand {
-   TextMessageEvent event;
+
+   private TextMessageEvent event;
 
    /**
-    * Create a KickCommand instance to handle console executions.
-    * @param input
+    * Create a KickCommand instance to handle console execution.
+    *
+    * @param input the string read in from the console that triggered this command.
     */
    public KickCommand(String input) {
-
+      try {
+         handle(input);
+      } catch (ArgumentMissingException | IllegalTargetException | InvalidUserIdException e) {
+         new MessageHandler(e.getMessage()).sendToConsoleWith("COMMAND RESPONSE");
+      }
    }
 
    /**
+    * Create a KickCommand instance to handle client execution.
     *
-    * @param event
+    * @param event the {@link TextMessageEvent} containing the call for this command.
     */
-   public KickCommand(TextMessageEvent event) throws Exception {
+   public KickCommand(TextMessageEvent event) {
       this.event = event;
-      String[] params = event.getMessage().split("\\s", 3);
 
-      int target = Integer.parseInt(params[1]);
-      String reason = params[2];
-
-      handle(target, reason);
+      try {
+         handle(event.getMessage());
+      } catch (ArgumentMissingException | IllegalTargetException | InvalidUserIdException e) {
+         new MessageHandler(e.getMessage()).sendToUser(event.getInvokerId());
+      }
    }
 
-   private void handle(int target, String reason) throws Exception {
-      TS3ApiAsync api = Executor.getServer("testInstance").getApiAsync();
-      String targetName = null;
+   private void handle(String input) throws ArgumentMissingException, IllegalTargetException,
+       InvalidUserIdException {
+      ServerConnectionManager instance = Executor.getServer("testInstance");
+      TS3ApiAsync api = instance.getApiAsync();
+      String[] params = input.split("\\s", 3);
+      int target = Integer.parseInt(params[1]);
+      String reason;
+      String targetName;
+
+      if (target == instance.getBotId()) {
+         throw new IllegalTargetException();
+      }
+
+      //Set reason, throwing ArgumentMissingException if not present.
+      try {
+         reason = params[2];
+      } catch (IndexOutOfBoundsException e) {
+         throw new ArgumentMissingException("kick", "reason");
+      }
+
+      //Determine target by ID, throwing InvalidUserIdException if no connected client has that ID.
       try {
          targetName = api.getClientInfo(target).getUninterruptibly().getNickname();
       } catch (Exception e) {
-         throw new Exception("No user is connected with that ID.");
+         if (e.getCause().getMessage().contains("invalid clientID")) {
+            throw new InvalidUserIdException(String.valueOf(target));
+         } else {
+            new MessageHandler(ErrorMessages.UNKNOWN_ERROR)
+                .sendToConsoleWith(Level.WARNING)
+                .sendToUser(event.getInvokerId());
+         }
+         return;
       }
-      api.kickClientFromServer(reason, target);
-      new MessageHandler(String.format("%s attempted to kick %s from the server for: %s", event
-          .getInvokerName(), targetName, event.getReasonMessage()))
-          .sendToConsoleWith("KICK");
+
+      //Log to console.
+      if (event != null) {
+         new MessageHandler(String.format("%s attempted to kick %s from the server for: %s", event
+             .getInvokerName(), targetName, reason))
+             .sendToConsoleWith("KICK");
+      } else {
+         new MessageHandler(String.format("Attempting to kick %s from the server for: %s",
+             targetName, reason))
+             .sendToConsoleWith("KICK");
+      }
+
+      //Execute kick.
+      api.kickClientFromServer(reason, target).onFailure(e ->
+          api.kickClientFromServer(reason, target));
    }
 }

--- a/src/main/core/commands/commands/KickCommand.java
+++ b/src/main/core/commands/commands/KickCommand.java
@@ -1,0 +1,47 @@
+package main.core.commands.commands;
+
+import com.github.theholywaffle.teamspeak3.TS3ApiAsync;
+import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
+import java.util.Objects;
+import main.core.Executor;
+import main.util.MessageHandler;
+
+public class KickCommand {
+   TextMessageEvent event;
+
+   /**
+    * Create a KickCommand instance to handle console executions.
+    * @param input
+    */
+   public KickCommand(String input) {
+
+   }
+
+   /**
+    *
+    * @param event
+    */
+   public KickCommand(TextMessageEvent event) throws Exception {
+      this.event = event;
+      String[] params = event.getMessage().split("\\s", 3);
+
+      int target = Integer.parseInt(params[1]);
+      String reason = params[2];
+
+      handle(target, reason);
+   }
+
+   private void handle(int target, String reason) throws Exception {
+      TS3ApiAsync api = Executor.getServer("testInstance").getApiAsync();
+      String targetName = null;
+      try {
+         targetName = api.getClientInfo(target).getUninterruptibly().getNickname();
+      } catch (Exception e) {
+         throw new Exception("No user is connected with that ID.");
+      }
+      api.kickClientFromServer(reason, target);
+      new MessageHandler(String.format("%s attempted to kick %s from the server for: %s", event
+          .getInvokerName(), targetName, event.getReasonMessage()))
+          .sendToConsoleWith("KICK");
+   }
+}

--- a/src/main/util/ErrorMessages.java
+++ b/src/main/util/ErrorMessages.java
@@ -4,7 +4,16 @@ package main.util;
  * Generic error messages to be used across the application.
  */
 public class ErrorMessages {
+
+   public final static String CANNOT_TARGET_BOT = "You cannot target the bot with that "
+       + "command.";
    public final static String COMMAND_NOT_FOUND = "%s is not a supported command.";
-   public final static String COMMAND_PREFIX_NOT_RECOGNIZED = "'%s' is not a recognized command prefix!";
-   public final static String INPUT_BLANK = "Space may be the final frontier, but sending me spaces does nothing!";
+   public final static String COMMAND_PREFIX_NOT_RECOGNIZED = "'%s' is not a recognized command"
+       + " prefix!";
+   public final static String INPUT_BLANK = "Space may be the final frontier, but sending me spaces"
+       + " does nothing!";
+   public final static String MISSING_ARGUMENT = "Command '%s' requires argument '%s'.";
+   public final static String NO_USER_WITH_ID = "No user is currently connected using id: %s";
+   public final static String UNKNOWN_ERROR = "Somewhere, something broke. Contact someone who "
+       + "knows what they're doing.";
 }

--- a/src/main/util/exception/ArgumentMissingException.java
+++ b/src/main/util/exception/ArgumentMissingException.java
@@ -1,0 +1,16 @@
+package main.util.exception;
+
+import main.util.ErrorMessages;
+
+public class ArgumentMissingException extends Exception {
+
+   /**
+    * Exception thrown when a command is missing required arguments.
+    *
+    * @param command the command being executed without proper arguments.
+    * @param argument the missing required argument.
+    */
+   public ArgumentMissingException(String command, String argument) {
+      super(String.format(ErrorMessages.MISSING_ARGUMENT, command, argument));
+   }
+}

--- a/src/main/util/exception/IllegalTargetException.java
+++ b/src/main/util/exception/IllegalTargetException.java
@@ -1,0 +1,15 @@
+package main.util.exception;
+
+import main.util.ErrorMessages;
+
+public class IllegalTargetException extends Exception {
+
+   /**
+    * Exception thrown when the application query connection is being targeted in a command which
+    * cannot be executed against it.
+    */
+   public IllegalTargetException() {
+      super(ErrorMessages.CANNOT_TARGET_BOT);
+   }
+
+}

--- a/src/main/util/exception/InvalidUserIdException.java
+++ b/src/main/util/exception/InvalidUserIdException.java
@@ -1,0 +1,15 @@
+package main.util.exception;
+
+import main.util.ErrorMessages;
+
+public class InvalidUserIdException extends Exception {
+
+   /**
+    * Exception thrown when an ID that does not belong to anybody is being targeted in a command.
+    *
+    * @param id the ID being targeted.
+    */
+   public InvalidUserIdException(String id) {
+      super(String.format(ErrorMessages.NO_USER_WITH_ID, id));
+   }
+}


### PR DESCRIPTION
# #14- Create KickUser Chat Command

## What was changed?  
Added KickUser (!kick) command.
Added exceptions for missing arguments, illegal target, and invalid userid.
Updated README.md to include use information.

## Why was it necessary?  
The addition of this command allows remote moderation of the server from the operator's machine in the form of removing users from the server.

## How was it tested?  
Manually on a local TS3 server.
