### PR TITLE
INCOBOT-17 & INCOBOT-20 - Extract/Standardize Logging Prefixes

### DIFF
--- a/src/main/core/commands/Commands.java
+++ b/src/main/core/commands/Commands.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
 import main.core.commands.commands.KickCommand;
 import main.core.commands.commands.PingCommand;
-import main.util.ErrorMessages;
+import main.util.Messages;
 import main.util.exception.AuthorizationException;
 import main.util.exception.CommandNotFoundException;
 import org.apache.commons.lang3.StringUtils;
@@ -79,8 +79,8 @@ public class Commands {
    }
 
    private static void validate(final String input) {
-      checkArgument(!StringUtils.isBlank(input), ErrorMessages.INPUT_BLANK);
+      checkArgument(!StringUtils.isBlank(input), Messages.INPUT_BLANK);
       checkArgument(input.startsWith(prefix),
-          String.format(ErrorMessages.COMMAND_PREFIX_NOT_RECOGNIZED, input.substring(0, 1)));
+          String.format(Messages.COMMAND_PREFIX_NOT_RECOGNIZED, input.substring(0, 1)));
    }
 }

--- a/src/main/core/commands/Commands.java
+++ b/src/main/core/commands/Commands.java
@@ -79,8 +79,8 @@ public class Commands {
    }
 
    private static void validate(final String input) {
-      checkArgument(!StringUtils.isBlank(input), Messages.INPUT_BLANK);
+      checkArgument(!StringUtils.isBlank(input), Messages.ERROR_INPUT_BLANK);
       checkArgument(input.startsWith(prefix),
-          String.format(Messages.COMMAND_PREFIX_NOT_RECOGNIZED, input.substring(0, 1)));
+          String.format(Messages.ERROR_COMMAND_PREFIX_NOT_RECOGNIZED, input.substring(0, 1)));
    }
 }

--- a/src/main/core/commands/commands/KickCommand.java
+++ b/src/main/core/commands/commands/KickCommand.java
@@ -90,7 +90,7 @@ public class KickCommand {
          if (e.getCause().getMessage().contains("invalid clientID")) {
             throw new InvalidUserIdException(String.valueOf(target));
          } else {
-            new MessageHandler(Messages.UNKNOWN_ERROR)
+            new MessageHandler(Messages.ERROR_UNKNOWN_ERROR)
                 .sendToConsoleWith(Level.WARNING)
                 .sendToUser(event.getInvokerId());
          }

--- a/src/main/core/commands/commands/KickCommand.java
+++ b/src/main/core/commands/commands/KickCommand.java
@@ -8,6 +8,7 @@ import main.core.Executor;
 import main.core.commands.AccessManager;
 import main.server.ServerConnectionManager;
 import main.util.ErrorMessages;
+import main.util.LogPrefix;
 import main.util.MessageHandler;
 import main.util.enums.AccessLevel;
 import main.util.exception.ArgumentMissingException;
@@ -33,7 +34,7 @@ public class KickCommand {
       try {
          handle(input);
       } catch (ArgumentMissingException | IllegalTargetException | InvalidUserIdException e) {
-         new MessageHandler(e.getMessage()).sendToConsoleWith("COMMAND RESPONSE");
+         new MessageHandler(e.getMessage()).sendToConsoleWith(LogPrefix.COMMAND_RESPONSE);
       }
    }
 
@@ -100,11 +101,11 @@ public class KickCommand {
       if (event != null) {
          new MessageHandler(String.format("%s attempted to kick %s from the server for: %s", event
              .getInvokerName(), targetName, reason))
-             .sendToConsoleWith("KICK");
+             .sendToConsoleWith(LogPrefix.KICK);
       } else {
          new MessageHandler(String.format("Attempting to kick %s from the server for: %s",
              targetName, reason))
-             .sendToConsoleWith("KICK");
+             .sendToConsoleWith(LogPrefix.KICK);
       }
 
       //Execute kick.

--- a/src/main/core/commands/commands/KickCommand.java
+++ b/src/main/core/commands/commands/KickCommand.java
@@ -7,7 +7,7 @@ import main.conf.ConfigHandler;
 import main.core.Executor;
 import main.core.commands.AccessManager;
 import main.server.ServerConnectionManager;
-import main.util.ErrorMessages;
+import main.util.Messages;
 import main.util.LogPrefix;
 import main.util.MessageHandler;
 import main.util.enums.AccessLevel;
@@ -90,7 +90,7 @@ public class KickCommand {
          if (e.getCause().getMessage().contains("invalid clientID")) {
             throw new InvalidUserIdException(String.valueOf(target));
          } else {
-            new MessageHandler(ErrorMessages.UNKNOWN_ERROR)
+            new MessageHandler(Messages.UNKNOWN_ERROR)
                 .sendToConsoleWith(Level.WARNING)
                 .sendToUser(event.getInvokerId());
          }

--- a/src/main/core/commands/commands/PingCommand.java
+++ b/src/main/core/commands/commands/PingCommand.java
@@ -7,6 +7,7 @@ import main.conf.ConfigHandler;
 import main.core.Executor;
 import main.core.commands.AccessManager;
 import main.server.ServerConnectionManager;
+import main.util.LogPrefix;
 import main.util.MessageHandler;
 import main.util.enums.AccessLevel;
 import main.util.exception.AuthorizationException;
@@ -53,17 +54,17 @@ public class PingCommand {
       final String RETURN_TEXT = "Pong!";
 
       if (event == null) {
-         new MessageHandler(RETURN_TEXT).sendToConsoleWith("COMMAND RESPONSE");
+         new MessageHandler(RETURN_TEXT).sendToConsoleWith(LogPrefix.COMMAND_RESPONSE);
          return;
       }
 
       TextMessageTargetMode mode = event.getTargetMode();
       if (mode == TextMessageTargetMode.SERVER) {
-         new MessageHandler(RETURN_TEXT).sendToConsoleWith("COMMAND RESPONSE").sendToServer();
+         new MessageHandler(RETURN_TEXT).sendToConsoleWith(LogPrefix.COMMAND_RESPONSE).sendToServer();
       } else if (mode == TextMessageTargetMode.CHANNEL) {
-         new MessageHandler(RETURN_TEXT).sendToConsoleWith("COMMAND RESPONSE").sendToChannel();
+         new MessageHandler(RETURN_TEXT).sendToConsoleWith(LogPrefix.COMMAND_RESPONSE).sendToChannel();
       } else if (mode == TextMessageTargetMode.CLIENT) {
-         new MessageHandler(RETURN_TEXT).sendToConsoleWith("COMMAND RESPONSE").returnToSender(event);
+         new MessageHandler(RETURN_TEXT).sendToConsoleWith(LogPrefix.COMMAND_RESPONSE).returnToSender(event);
       }
    }
 }

--- a/src/main/server/ServerConnectionManager.java
+++ b/src/main/server/ServerConnectionManager.java
@@ -155,6 +155,7 @@ public class ServerConnectionManager {
     *
     * @param api the {@code TS3Appi} to be receiving the listeners.
     */
+   @Deprecated
    private void addListeners(final TS3Api api) {
       api.addTS3Listeners(new TS3EventAdapter() {
          @Override

--- a/src/main/server/listeners/handlers/ClientJoinHandler.java
+++ b/src/main/server/listeners/handlers/ClientJoinHandler.java
@@ -15,6 +15,9 @@ import java.net.URLEncoder;
 import java.util.List;
 import main.core.Config;
 import main.core.Executor;
+import main.util.ErrorMessages;
+import main.util.LogPrefix;
+import main.util.MessageHandler;
 import main.util.Util;
 
 /**
@@ -82,12 +85,13 @@ public class ClientJoinHandler {
    private void logToConsole() {
       final String channelName = api.getChannelInfo(event.getClientTargetId()).getName();
 
-      String logMessage = Util.timeStamp() + "[CONNECTION] "
-          + event.getClientNickname()
-          + " (" + event.getUniqueClientIdentifier() + ") "
-          + "connected to \"" + channelName + "\"";
-
-      System.out.println(logMessage);
+      new MessageHandler(
+          String.format(
+              ErrorMessages.USER_CONNECTED,
+              event.getClientNickname(),
+              event.getUniqueClientIdentifier(),
+              channelName))
+          .sendToConsoleWith(LogPrefix.CONNECTION);
    }
 
    /**

--- a/src/main/server/listeners/handlers/ClientJoinHandler.java
+++ b/src/main/server/listeners/handlers/ClientJoinHandler.java
@@ -15,7 +15,7 @@ import java.net.URLEncoder;
 import java.util.List;
 import main.core.Config;
 import main.core.Executor;
-import main.util.ErrorMessages;
+import main.util.Messages;
 import main.util.LogPrefix;
 import main.util.MessageHandler;
 import main.util.Util;
@@ -87,7 +87,7 @@ public class ClientJoinHandler {
 
       new MessageHandler(
           String.format(
-              ErrorMessages.USER_CONNECTED,
+              Messages.USER_CONNECTED,
               event.getClientNickname(),
               event.getUniqueClientIdentifier(),
               channelName))

--- a/src/main/server/listeners/handlers/TextMessageHandler.java
+++ b/src/main/server/listeners/handlers/TextMessageHandler.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import main.core.Executor;
 import main.core.commands.Commands;
 import main.server.listeners.TextMessageListener;
+import main.util.LogPrefix;
 import main.util.MessageHandler;
 
 /**
@@ -57,20 +58,20 @@ public class TextMessageHandler {
          //User sent server/channel message.
          new MessageHandler(String.format("%s (%s) to %s: %s", invokerName, invokerUid, target,
              message))
-             .sendToConsoleWith("MESSAGE");
+             .sendToConsoleWith(LogPrefix.MESSAGE);
       } else if (target == TextMessageTargetMode.CLIENT && invokerId != botId) {
          //User sent private message to bot.
          new MessageHandler(String.format("%s to BOT: %s", invokerName, message))
-             .sendToConsoleWith("MESSAGE");
+             .sendToConsoleWith(LogPrefix.MESSAGE);
       } else if (target != TextMessageTargetMode.CLIENT) {
          //Bot sent server/channel message.
          new MessageHandler(String.format("BOT to SERVER: %s", message)).sendToConsoleWith
-             ("MESSAGE");
+             (LogPrefix.MESSAGE);
       } else { //Bot sent private message to user.
          final String targetUser = Executor.getServer("testInstance").getApi()
              .getClientInfo(event.getInt("target")).getNickname();
          new MessageHandler(String.format("BOT to %s: %s", targetUser, message))
-             .sendToConsoleWith("MESSAGE");
+             .sendToConsoleWith(LogPrefix.MESSAGE);
       }
    }
 }

--- a/src/main/util/ErrorMessages.java
+++ b/src/main/util/ErrorMessages.java
@@ -19,4 +19,5 @@ public class ErrorMessages {
    public final static String NO_USER_WITH_ID = "No user is currently connected using id: %s";
    public final static String UNKNOWN_ERROR = "Somewhere, something broke. Contact someone who "
        + "knows what they're doing.";
+   public final static String USER_CONNECTED = "%s (%s) connected to \"%s\".";
 }

--- a/src/main/util/LogPrefix.java
+++ b/src/main/util/LogPrefix.java
@@ -1,0 +1,8 @@
+package main.util;
+
+public class LogPrefix {
+   public final static String MESSAGE = "MESSAGE";
+   public final static String COMMAND_RESPONSE = "COMMAND RESPONSE";
+   public final static String KICK = "KICK";
+   public final static String CONNECTION = "CONNECTION";
+}

--- a/src/main/util/Messages.java
+++ b/src/main/util/Messages.java
@@ -3,7 +3,7 @@ package main.util;
 /**
  * Generic error messages to be used across the application.
  */
-public class ErrorMessages {
+public class Messages {
    public final static String ACCESS_LIST_CANNOT_USE_COMMAND = "The '%s' access list does not "
        + "have permissions to use command '%s'";
    public final static String CANNOT_TARGET_BOT = "You cannot target the bot with that "

--- a/src/main/util/Messages.java
+++ b/src/main/util/Messages.java
@@ -4,20 +4,20 @@ package main.util;
  * Generic error messages to be used across the application.
  */
 public class Messages {
-   public final static String ACCESS_LIST_CANNOT_USE_COMMAND = "The '%s' access list does not "
+   public final static String ERROR_ACCESS_LIST_CANNOT_USE_COMMAND = "The '%s' access list does not "
        + "have permissions to use command '%s'";
-   public final static String CANNOT_TARGET_BOT = "You cannot target the bot with that "
+   public final static String ERROR_CANNOT_TARGET_BOT = "You cannot target the bot with that "
        + "command.";
-   public final static String COMMAND_NOT_FOUND = "%s is not a supported command.";
-   public final static String COMMAND_PREFIX_NOT_RECOGNIZED = "'%s' is not a recognized command"
+   public final static String ERROR_COMMAND_NOT_FOUND = "%s is not a supported command.";
+   public final static String ERROR_COMMAND_PREFIX_NOT_RECOGNIZED = "'%s' is not a recognized command"
        + " prefix!";
-   public final static String INPUT_BLANK = "Space may be the final frontier, but sending me spaces"
+   public final static String ERROR_INPUT_BLANK = "Space may be the final frontier, but sending me spaces"
        + " does nothing!";
-   public final static String LEVEL_LOWER_THAN_REQUIRED = "The provided access level of %s is "
+   public final static String ERROR_LEVEL_LOWER_THAN_REQUIRED = "The provided access level of %s is "
        + "lower than the required access level of %s.";
-   public final static String MISSING_ARGUMENT = "Command '%s' requires argument '%s'.";
-   public final static String NO_USER_WITH_ID = "No user is currently connected using id: %s";
-   public final static String UNKNOWN_ERROR = "Somewhere, something broke. Contact someone who "
+   public final static String ERROR_MISSING_ARGUMENT = "Command '%s' requires argument '%s'.";
+   public final static String ERROR_NO_USER_WITH_ID = "No user is currently connected using id: %s";
+   public final static String ERROR_UNKNOWN_ERROR = "Somewhere, something broke. Contact someone who "
        + "knows what they're doing.";
    public final static String USER_CONNECTED = "%s (%s) connected to \"%s\".";
 }

--- a/src/main/util/exception/ArgumentMissingException.java
+++ b/src/main/util/exception/ArgumentMissingException.java
@@ -1,6 +1,6 @@
 package main.util.exception;
 
-import main.util.ErrorMessages;
+import main.util.Messages;
 
 public class ArgumentMissingException extends Exception {
 
@@ -11,6 +11,6 @@ public class ArgumentMissingException extends Exception {
     * @param argument the missing required argument.
     */
    public ArgumentMissingException(String command, String argument) {
-      super(String.format(ErrorMessages.MISSING_ARGUMENT, command, argument));
+      super(String.format(Messages.MISSING_ARGUMENT, command, argument));
    }
 }

--- a/src/main/util/exception/ArgumentMissingException.java
+++ b/src/main/util/exception/ArgumentMissingException.java
@@ -11,6 +11,6 @@ public class ArgumentMissingException extends Exception {
     * @param argument the missing required argument.
     */
    public ArgumentMissingException(String command, String argument) {
-      super(String.format(Messages.MISSING_ARGUMENT, command, argument));
+      super(String.format(Messages.ERROR_MISSING_ARGUMENT, command, argument));
    }
 }

--- a/src/main/util/exception/AuthorizationException.java
+++ b/src/main/util/exception/AuthorizationException.java
@@ -1,14 +1,14 @@
 package main.util.exception;
 
-import main.util.ErrorMessages;
+import main.util.Messages;
 import main.util.enums.AccessLevel;
 
 public class AuthorizationException extends Exception {
    public AuthorizationException(String required, String given) {
-      super(String.format(ErrorMessages.LEVEL_LOWER_THAN_REQUIRED, required, given));
+      super(String.format(Messages.LEVEL_LOWER_THAN_REQUIRED, required, given));
    }
 
    public AuthorizationException(AccessLevel level, String command) {
-      super(String.format(ErrorMessages.ACCESS_LIST_CANNOT_USE_COMMAND, level.toString(), command));
+      super(String.format(Messages.ACCESS_LIST_CANNOT_USE_COMMAND, level.toString(), command));
    }
 }

--- a/src/main/util/exception/AuthorizationException.java
+++ b/src/main/util/exception/AuthorizationException.java
@@ -5,10 +5,10 @@ import main.util.enums.AccessLevel;
 
 public class AuthorizationException extends Exception {
    public AuthorizationException(String required, String given) {
-      super(String.format(Messages.LEVEL_LOWER_THAN_REQUIRED, required, given));
+      super(String.format(Messages.ERROR_LEVEL_LOWER_THAN_REQUIRED, required, given));
    }
 
    public AuthorizationException(AccessLevel level, String command) {
-      super(String.format(Messages.ACCESS_LIST_CANNOT_USE_COMMAND, level.toString(), command));
+      super(String.format(Messages.ERROR_ACCESS_LIST_CANNOT_USE_COMMAND, level.toString(), command));
    }
 }

--- a/src/main/util/exception/CommandNotFoundException.java
+++ b/src/main/util/exception/CommandNotFoundException.java
@@ -1,16 +1,16 @@
 package main.util.exception;
 
-import main.util.ErrorMessages;
+import main.util.Messages;
 
 /**
  * Exception used when a command is given but cannot be matched to an existing command.
  */
 public class CommandNotFoundException extends Exception {
    public CommandNotFoundException() {
-      super(String.format(ErrorMessages.COMMAND_NOT_FOUND, "The input provided"));
+      super(String.format(Messages.COMMAND_NOT_FOUND, "The input provided"));
    }
 
    public CommandNotFoundException(String invalidCommand) {
-      super(String.format(ErrorMessages.COMMAND_NOT_FOUND, "\'" + invalidCommand + "\'"));
+      super(String.format(Messages.COMMAND_NOT_FOUND, "\'" + invalidCommand + "\'"));
    }
 }

--- a/src/main/util/exception/CommandNotFoundException.java
+++ b/src/main/util/exception/CommandNotFoundException.java
@@ -7,10 +7,10 @@ import main.util.Messages;
  */
 public class CommandNotFoundException extends Exception {
    public CommandNotFoundException() {
-      super(String.format(Messages.COMMAND_NOT_FOUND, "The input provided"));
+      super(String.format(Messages.ERROR_COMMAND_NOT_FOUND, "The input provided"));
    }
 
    public CommandNotFoundException(String invalidCommand) {
-      super(String.format(Messages.COMMAND_NOT_FOUND, "\'" + invalidCommand + "\'"));
+      super(String.format(Messages.ERROR_COMMAND_NOT_FOUND, "\'" + invalidCommand + "\'"));
    }
 }

--- a/src/main/util/exception/IllegalTargetException.java
+++ b/src/main/util/exception/IllegalTargetException.java
@@ -9,7 +9,7 @@ public class IllegalTargetException extends Exception {
     * cannot be executed against it.
     */
    public IllegalTargetException() {
-      super(Messages.CANNOT_TARGET_BOT);
+      super(Messages.ERROR_CANNOT_TARGET_BOT);
    }
 
 }

--- a/src/main/util/exception/IllegalTargetException.java
+++ b/src/main/util/exception/IllegalTargetException.java
@@ -1,6 +1,6 @@
 package main.util.exception;
 
-import main.util.ErrorMessages;
+import main.util.Messages;
 
 public class IllegalTargetException extends Exception {
 
@@ -9,7 +9,7 @@ public class IllegalTargetException extends Exception {
     * cannot be executed against it.
     */
    public IllegalTargetException() {
-      super(ErrorMessages.CANNOT_TARGET_BOT);
+      super(Messages.CANNOT_TARGET_BOT);
    }
 
 }

--- a/src/main/util/exception/InvalidUserIdException.java
+++ b/src/main/util/exception/InvalidUserIdException.java
@@ -1,6 +1,6 @@
 package main.util.exception;
 
-import main.util.ErrorMessages;
+import main.util.Messages;
 
 public class InvalidUserIdException extends Exception {
 
@@ -10,6 +10,6 @@ public class InvalidUserIdException extends Exception {
     * @param id the ID being targeted.
     */
    public InvalidUserIdException(String id) {
-      super(String.format(ErrorMessages.NO_USER_WITH_ID, id));
+      super(String.format(Messages.NO_USER_WITH_ID, id));
    }
 }

--- a/src/main/util/exception/InvalidUserIdException.java
+++ b/src/main/util/exception/InvalidUserIdException.java
@@ -10,6 +10,6 @@ public class InvalidUserIdException extends Exception {
     * @param id the ID being targeted.
     */
    public InvalidUserIdException(String id) {
-      super(String.format(Messages.NO_USER_WITH_ID, id));
+      super(String.format(Messages.ERROR_NO_USER_WITH_ID, id));
    }
 }


### PR DESCRIPTION
# #17 and #20 - Extract/standardize logging prefixes.

## What was changed?  
New file created to hold logging message prefixes. All existing logging messages were uplifted to use the standardized values. ErrorMessages was refactored to become more generic.

## Why was it necessary?  
This change ensures future changes involving logging messages are consistent with prior/existing logging message prefixes.

## How was it tested?  
Manual testing by triggering events on a local test server to ensure logging messages remained the same, as expected.
