### PR TITLE
INCOBOT-30 Add Display Messages for Clients Changing Channels

### DIFF
--- a/src/main/server/ServerConnectionManager.java
+++ b/src/main/server/ServerConnectionManager.java
@@ -17,6 +17,7 @@ import main.conf.ConfigHandler;
 import main.conf.ConnectionConfiguration;
 import main.server.listeners.ClientConnectListener;
 import main.server.listeners.ClientDisconnectListener;
+import main.server.listeners.ClientMovedListener;
 import main.server.listeners.TextMessageListener;
 import main.util.MessageHandler;
 import main.util.Messages;
@@ -84,6 +85,7 @@ public class ServerConnectionManager {
             api.addTS3Listeners(new TextMessageListener());
             api.addTS3Listeners(new ClientConnectListener());
             api.addTS3Listeners(new ClientDisconnectListener());
+            api.addTS3Listeners(new ClientMovedListener());
 
             //TODO: Remove; added for testing.
 //            new MessageHandler("Blah!").sendToServer();

--- a/src/main/server/listeners/ClientMovedListener.java
+++ b/src/main/server/listeners/ClientMovedListener.java
@@ -4,6 +4,9 @@ import com.github.theholywaffle.teamspeak3.api.event.ClientMovedEvent;
 import com.github.theholywaffle.teamspeak3.api.event.TS3EventAdapter;
 import main.server.listeners.handlers.ClientMovedHandler;
 
+/**
+ * Custom implementation of {@link ClientMovedEvent} listener.
+ */
 public class ClientMovedListener extends TS3EventAdapter {
 
    private boolean consoleLoggingOn = false;

--- a/src/main/server/listeners/ClientMovedListener.java
+++ b/src/main/server/listeners/ClientMovedListener.java
@@ -1,0 +1,19 @@
+package main.server.listeners;
+
+import com.github.theholywaffle.teamspeak3.api.event.ClientMovedEvent;
+import com.github.theholywaffle.teamspeak3.api.event.TS3EventAdapter;
+import main.server.listeners.handlers.ClientMovedHandler;
+
+public class ClientMovedListener extends TS3EventAdapter {
+
+   private boolean consoleLoggingOn = false;
+   private boolean fileLoggingOn = false;
+
+   @Override
+   public void onClientMoved(ClientMovedEvent movedEvent) {
+      consoleLoggingOn = true;
+      fileLoggingOn = false;
+
+      new ClientMovedHandler(movedEvent, consoleLoggingOn, fileLoggingOn);
+   }
+}

--- a/src/main/server/listeners/handlers/ClientJoinHandler.java
+++ b/src/main/server/listeners/handlers/ClientJoinHandler.java
@@ -20,7 +20,7 @@ import main.util.Messages;
 import main.util.Util;
 
 /**
- * Logic and helper functions used to handle the firing of a {@link ClientConnectListener}
+ * Logic and helper functions used to handle the firing of a {@link ClientJoinEvent}.
  */
 public class ClientJoinHandler {
 
@@ -30,6 +30,14 @@ public class ClientJoinHandler {
    private ClientInfo clientInfo;
    private List<ServerGroup> serverGroups;
 
+   /**
+    * Creates a new {@link ClientJoinHandler} with the provided {@link ClientJoinEvent} and logging
+    * settings.
+    *
+    * @param event the {@code ClientJoinEvent} being acted upon.
+    * @param consoleLogging whether or not this event should be logged to the console.
+    * @param fileLogging whether or not this event should be logged to a file.
+    */
    public ClientJoinHandler(ClientJoinEvent event, boolean consoleLogging, boolean fileLogging) {
       this.event = event;
       this.client = api.getClientByUId(event.getUniqueClientIdentifier());

--- a/src/main/server/listeners/handlers/ClientMovedHandler.java
+++ b/src/main/server/listeners/handlers/ClientMovedHandler.java
@@ -1,0 +1,66 @@
+package main.server.listeners.handlers;
+
+import com.github.theholywaffle.teamspeak3.TS3Api;
+import com.github.theholywaffle.teamspeak3.api.event.ClientMovedEvent;
+import com.github.theholywaffle.teamspeak3.api.wrapper.ClientInfo;
+import java.util.logging.Level;
+import main.core.Executor;
+import main.util.MessageHandler;
+import main.util.Messages;
+
+/**
+ * Logic and helper functions used to handle the firing of a {@link ClientMovedEvent}.
+ */
+public class ClientMovedHandler {
+
+   private final TS3Api api = Executor.getServer("testInstance").getApi();
+   private ClientMovedEvent event;
+   private String movedName;
+   private String movedUid;
+   private String invokerName;
+   private String invokerUid;
+   private String channelName;
+
+   /**
+    * Creates a new {@link ClientMovedHandler} with the provided {@link ClientMovedEvent} and
+    * logging settings.
+    *
+    * @param event the {@code ClientMovedEvent} being acted upon.
+    * @param consoleLogging whether or not this event should be logged to the console.
+    * @param fileLogging whether or not this event should be logged to a file.
+    */
+   public ClientMovedHandler(ClientMovedEvent event, boolean consoleLogging, boolean fileLogging) {
+      ClientInfo movedClient;
+      movedClient = api.getClientInfo(event.getClientId());
+
+      this.event = event;
+      this.movedName = movedClient.getNickname();
+      this.movedUid = movedClient.getUniqueIdentifier();
+      this.invokerName = event.getInvokerName();
+      this.invokerUid = event.getInvokerUniqueId();
+      this.channelName = api.getChannelInfo(event.getTargetChannelId()).getName();
+
+      if (consoleLogging) {
+         getMessageHandler().sendToConsoleWith(Level.INFO);
+      }
+
+      if (fileLogging) {
+         logToFile();
+      }
+   }
+
+   private void logToFile() {
+      // TODO Auto-generated method stub
+   }
+
+   private MessageHandler getMessageHandler() {
+      if (invokerName.isEmpty()) {
+         return new MessageHandler(String.format(Messages.USER_MOVED, movedName, movedUid,
+             channelName));
+      } else {
+         return new MessageHandler(
+             String.format(Messages.USER_WAS_MOVED, invokerName, invokerUid, movedName, movedUid,
+                 channelName));
+      }
+   }
+}

--- a/src/main/util/Messages.java
+++ b/src/main/util/Messages.java
@@ -43,6 +43,8 @@ public class Messages {
    public final static String USER_KICKED = "%s (%s) was kicked from the server by %s (%s) for "
        + "reason: %s";
    public final static String USER_LOST_CONNECTION = "%s (%s) lost connection to the server.";
+   public final static String USER_MOVED = "%s (%s) moved to \"%s\".";
+   public final static String USER_WAS_MOVED = "%s (%s) moved %s (%s) to \"%s\".";
    public final static String YOU_HAVE_BEEN_MOVED = "You have been moved to \"%s\" for being idle"
        + " longer than %s minutes.";
 }


### PR DESCRIPTION
# #30 - Add Display Messages for Clients Changing Channels  

## What was changed?  
Added event listener and logging for ClientMovedEvent.  
Messages distinguish between voluntary and forced moves.  

## Why was it necessary?  
Provides better view of the server's activity for program administrators.

## How was it tested?  
Tested manually in a live server environment by moving voluntarily and forcefully moving a client to ensure the messages were correct and triggered when expected.
