### PR TITLE
INCOBOT-40 IdleChecker Running Multiple Instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ hs_err_pid*
 target/
 /conbot.iml
 /.idea/
+/incobot-ts3.iml

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,5 @@ hs_err_pid*
 .project
 .settings/*
 target/
-/conbot.iml
 /.idea/
 /incobot-ts3.iml

--- a/src/main/core/functions/IdleChecker.java
+++ b/src/main/core/functions/IdleChecker.java
@@ -20,14 +20,56 @@ import main.util.Messages;
  */
 public class IdleChecker extends TimerTask {
 
+   private static IdleChecker idleChecker;
+   private static Timer idleCheckerTimer;
+   private static Boolean isActive = false;
    private IdleCheckConfiguration config = ConfigHandler.readIdleCheckConfig(
        new File("./config/IdleChecker.yaml"));
    private TS3ApiAsync api = Executor.getServer("testInstance").getApiAsync();
    private int maxIdleTimeMilliseconds = config.getMaxTimeMinutes() * 60000;
    private int botClientId = Executor.getServer("testInstance").getBotId();
 
-   private static IdleChecker idleChecker;
-   private static Timer idleCheckerTimer;
+   /**
+    * Begins execution of the Idle Checker loop.
+    */
+   public static String start() {
+      if (!isActive) {
+         String destinationChannelName;
+
+         idleChecker = new IdleChecker();
+         idleCheckerTimer = new Timer();
+
+         try {
+            destinationChannelName = idleChecker.api.getChannelInfo(idleChecker.config
+                .getDestinationChannel()).getUninterruptibly().getName();
+         } catch (Exception e) {
+            throw new NullPointerException(String
+                .format(Messages.CHANNEL_NOT_FOUND, idleChecker.config.getDestinationChannel()));
+         }
+
+         idleCheckerTimer.schedule(idleChecker, 0, 1000);
+         isActive = true;
+         return String.format(Messages.IDLE_CHECK_ENABLED, destinationChannelName, idleChecker
+             .config.getMaxTimeMinutes());
+      } else {
+         return String.format(Messages.IDLE_CHECK_CANNOT_COMPLETE_ACTION, "enabled");
+      }
+   }
+
+   /**
+    * Stops execution of the Idle Checker loop.
+    */
+   public static String stop() {
+      if (isActive) {
+         idleChecker.cancel();
+         idleCheckerTimer.cancel();
+         idleCheckerTimer.purge();
+         isActive = false;
+         return Messages.IDLE_CHECK_DISABLED;
+      } else {
+         return String.format(Messages.IDLE_CHECK_CANNOT_COMPLETE_ACTION, "disabled");
+      }
+   }
 
    @Override
    public void run() {
@@ -36,28 +78,6 @@ public class IdleChecker extends TimerTask {
          List<Client> applicableClients = getApplicableClients(e);
          moveIdleUsersFromList(applicableClients);
       });
-   }
-
-   /**
-    * Begins execution of the Idle Checker loop.
-    */
-   public static void start() {
-      idleChecker = new IdleChecker();
-      idleCheckerTimer = new Timer();
-      idleCheckerTimer.schedule(idleChecker, 0, 1000);
-      new MessageHandler(String.format(Messages.IDLE_CHECK_ENABLED, idleChecker.api
-          .getChannelInfo(idleChecker.config.getDestinationChannel()).getUninterruptibly()
-          .getName(), idleChecker.config.getMaxTimeMinutes())).sendToConsoleWith(LogPrefix.IDLE);
-   }
-
-   /**
-    * Stops execution of the Idle Checker loop.
-    */
-   public static void stop() {
-      idleChecker.cancel();
-      idleCheckerTimer.cancel();
-      idleCheckerTimer.purge();
-      new MessageHandler(Messages.IDLE_CHECK_DISABLED).sendToConsoleWith(LogPrefix.IDLE);
    }
 
    /**

--- a/src/main/util/Messages.java
+++ b/src/main/util/Messages.java
@@ -5,6 +5,8 @@ package main.util;
  */
 public class Messages {
 
+   public final static String CHANNEL_NOT_FOUND = "No channel found for id: %s. Please check "
+       + "config settings.";
    public final static String CLIENT_MOVED_FOR_INACTIVITY = "%s (%s) has been moved for being "
        + "idle for %s minutes.";
    public final static String ERROR_ACCESS_LIST_CANNOT_USE_COMMAND =
@@ -29,6 +31,8 @@ public class Messages {
    public final static String ERROR_UNKNOWN_ERROR =
        "Somewhere, something broke. Contact someone who "
            + "knows what they're doing.";
+   public final static String IDLE_CHECK_CANNOT_COMPLETE_ACTION = "Action cannot be completed. "
+       + "Idle Check is already %s.";
    public final static String IDLE_CHECK_DISABLED = "Idle Check disabled. Idle users will no "
        + "longer be automatically moved.";
    public final static String IDLE_CHECK_ENABLED = "Idle Check enabled. Idle users will now be "


### PR DESCRIPTION
# #40 - IdleChecker Running Multiple Instances

## What was changed?  
Added `isActive` check to `!idlechecker enable` and `!idlechecker disable` implementation to prevent the bot from starting multiple IdleChecker instances.

## Why was it necessary?  
Defect fix. IdleChecker should not be able to run multiple instances, as doing so increases resource consumption and the possibility of adverse effects on the moderated server.

## How was it tested?  
Manually in a private test environment with the following scenarios:
 - Attempted to disable IdleChecker before enabling it.
 - Enabled IdleChecker, then attempted to enable it again.
 - Disabled IdleChecker, then attempted to disable it again.
