### PR TITLE
INCOBOT-41 Add Status Check to IdleChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ blacklisted-groups:
 ```
   
 ### Idle Checker Configuration
-Establish a set time in minutes before idle users are automatically moved to a designated channel. Users can be exempt from the check by being added to one of the groups listed as an ignore 
+Establish a set time in minutes before idle users are automatically moved to a designated channel. Users can be exempt from the check by being added to one of the groups listed as an ignore
 group in the IdleChecker.yaml file. IdleChecker must be restarted for config changes to take 
 effect if changes are made to the file while it is running.  
 For control information, see [Idle Checker](#idle-checker).
@@ -57,12 +57,19 @@ idle-ignore-groups:
 
 ## Active Administration
 ### Idle Checker
+**Minimum Permission Level:** Admin
 Dual-side support for controlling whether or not the bot will check for (and move) idle users.
-**Minimum Permission Level:** Admin  
+For configuration information, see [Idle Checker Configuration](#idle-checker-configuration).
+
+#### Commands
+##### Toggle Module
 **Syntax:** `!idlechecker <enable | disable>`  
 **Use:** Enables or disables the IdleChecker functionality. When enabled, users will be moved to 
 the designated idle channel after a certain threshold of time.  
-For additional information, see [Idle Checker Configuration](#idle-checker-configuration).  
+
+#### Check Module Status
+**Syntax:** `!idlechecker`, `!idlechecker status`
+**Use:** Displays whether or not Idle Checker is running. If it is running, this command also displays the threshold at which time users will be moved, and the name of the channel to which the idle user will be moved.
   
 ### Kick
 Dual-side support for forced disconnects of connected clients.  

--- a/src/main/core/commands/commands/IdleCheckerCommand.java
+++ b/src/main/core/commands/commands/IdleCheckerCommand.java
@@ -68,23 +68,26 @@ public class IdleCheckerCommand {
       String[] params = input.split("\\s", 2);
       MessageHandler messageHandler;
 
-      if (params.length != 2) {
+      if (params.length == 2) {
+         switch (params[1]) {
+            case "enable":
+               messageHandler = new MessageHandler(IdleChecker.start());
+               break;
+            case "disable":
+               messageHandler = new MessageHandler(IdleChecker.stop());
+               break;
+            case "status":
+               messageHandler = new MessageHandler(IdleChecker.getStatusReport());
+               break;
+            default:
+               throw new Exception("Unrecognized action. Please refer to documentation. Accepted "
+                   + "actions: 'enable', 'disable'");
+         }
+      } else if (params.length == 1) {
+         messageHandler = new MessageHandler(IdleChecker.getStatusReport());
+      } else {
          throw new ArgumentMissingException("idlechecker", "action");
       }
-
-      switch (params[1]) {
-         case "enable":
-            messageHandler = new MessageHandler(IdleChecker.start());
-            break;
-         case "disable":
-            messageHandler = new MessageHandler(IdleChecker.stop());
-            break;
-         default:
-            throw new Exception("Unrecognized action. Please refer to documentation. Accepted "
-                + "actions: 'enable', 'disable'");
-      }
-
-      messageHandler.sendToConsoleWith(LogPrefix.IDLE);
 
       if (event != null) {
          if (event.getTargetMode() == TextMessageTargetMode.SERVER) {
@@ -94,6 +97,8 @@ public class IdleCheckerCommand {
          } else if (event.getTargetMode() == TextMessageTargetMode.CLIENT) {
             messageHandler.returnToSender(event);
          }
+      } else {
+         messageHandler.sendToConsoleWith(LogPrefix.IDLE);
       }
    }
 }

--- a/src/main/core/functions/IdleChecker.java
+++ b/src/main/core/functions/IdleChecker.java
@@ -28,14 +28,14 @@ public class IdleChecker extends TimerTask {
    private TS3ApiAsync api = Executor.getServer("testInstance").getApiAsync();
    private int maxIdleTimeMilliseconds = config.getMaxTimeMinutes() * 60000;
    private int botClientId = Executor.getServer("testInstance").getBotId();
+   private static String destinationChannelName;
+   private static Integer maxIdleTime;
 
    /**
     * Begins execution of the Idle Checker loop.
     */
    public static String start() {
       if (!isActive) {
-         String destinationChannelName;
-
          idleChecker = new IdleChecker();
          idleCheckerTimer = new Timer();
 
@@ -46,11 +46,11 @@ public class IdleChecker extends TimerTask {
             throw new NullPointerException(String
                 .format(Messages.CHANNEL_NOT_FOUND, idleChecker.config.getDestinationChannel()));
          }
+         maxIdleTime = idleChecker.config.getMaxTimeMinutes();
 
          idleCheckerTimer.schedule(idleChecker, 0, 1000);
          isActive = true;
-         return String.format(Messages.IDLE_CHECK_ENABLED, destinationChannelName, idleChecker
-             .config.getMaxTimeMinutes());
+         return String.format(Messages.IDLE_CHECK_ENABLED, destinationChannelName, maxIdleTime);
       } else {
          return String.format(Messages.IDLE_CHECK_CANNOT_COMPLETE_ACTION, "enabled");
       }
@@ -68,6 +68,15 @@ public class IdleChecker extends TimerTask {
          return Messages.IDLE_CHECK_DISABLED;
       } else {
          return String.format(Messages.IDLE_CHECK_CANNOT_COMPLETE_ACTION, "disabled");
+      }
+   }
+
+   public static String getStatusReport() {
+      if (isActive) {
+         return String.format("Idle Checker is currently active. Users will be moved to \"%s\" "
+             + "after %s minutes of inactivity.", destinationChannelName, maxIdleTime);
+      } else {
+         return "Idle Checker is currently inactive.";
       }
    }
 


### PR DESCRIPTION
# #41 - Add Status Check to IdleChecker  

## What was changed?  
Added command syntax support to IdleChecker to allow users to check the status of that functionality.

## Why was it necessary?  
Allows users to determine information of the idle checker's configuration without needing to view the file or cycle the functionality.

## How was it tested?  
Manually on a private server with the following steps:
 - Call `!idlechecker` and `!idlechecker status` from server, channel, and private chat while idlechecker is off.
 - Call `!idlechecker` and `!idlechecker status` from server, channel, and private chat while idlechecker is on.
 - Call `!idlechecker` and `!idlechecker status` from console while idlechecker is off.
 - Call `!idlechecker` and `!idlechecker status` from console while idlechecker is on.
