### PR TITLE
INCOBOT-43 Add Command Aliases for Idle Checker

### DIFF
--- a/src/main/core/commands/Commands.java
+++ b/src/main/core/commands/Commands.java
@@ -32,6 +32,8 @@ public class Commands {
       final String action = command[0].substring(1);
 
       switch (action.toLowerCase()) {
+         case "idle":
+         case "idlecheck":
          case "idlechecker":
             new IdleCheckerCommand(input);
             return;

--- a/src/main/core/commands/commands/IdleCheckerCommand.java
+++ b/src/main/core/commands/commands/IdleCheckerCommand.java
@@ -69,14 +69,16 @@ public class IdleCheckerCommand {
       MessageHandler messageHandler;
 
       if (params.length != 2) {
-         throw new ArgumentMissingException("idlechecker", "action");
+         throw new ArgumentMissingException(params[0], "action");
       }
 
       switch (params[1]) {
          case "enable":
+         case "on":
             messageHandler = new MessageHandler(IdleChecker.start());
             break;
          case "disable":
+         case "off":
             messageHandler = new MessageHandler(IdleChecker.stop());
             break;
          default:


### PR DESCRIPTION
# #43  - Add command aliases for IdleChecker  

## What was changed?  
Added "idle" and "idecheck" command aliases for IdleChecker.
Added "on" alias for "enable". Added "off" alias for "disable".

## Why was it necessary?  
Enhances usability by being more forgiving for command or action names that should logically be accepted.

## How was it tested?  
Manually on a private test server.
