### PR TITLE
INCOBOT-53 Add comehere command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ idle-ignore-groups:
 
 ## Active Administration
 ### Idle Checker
-**Minimum Permission Level:** Admin
+**Minimum Permission Level:** Admin  
 Dual-side support for controlling whether or not the bot will check for (and move) idle users.
 For configuration information, see [Idle Checker Configuration](#idle-checker-configuration).
 
@@ -78,12 +78,18 @@ Dual-side support for forced disconnects of connected clients.
 **Use:** Kicks the client matching the clientId from the server with the provided reason.
 
 ### User Information
-Dual-side support for forced disconnect of connected clients.
-**Minimum Permission Level:** Moderator
-**Syntax:** `!userinfo (query)`
+Dual-side support for forced disconnect of connected clients.  
+**Minimum Permission Level:** Moderator  
+**Syntax:** `!userinfo (query)`  
 **Use:** Retrieves information about users whose names the query partially matches. Special query `@me` retrieves information about the user who called the command. Failing to provide a query results in all online users being returned.
     
 ## Communication Abilities
+### Come Here
+Server-side support for moving the bot to the caller's channel.  
+**Minimum Permission Level:** Default  
+**Syntax:** `!comehere`  
+**Use:** Moves the query bot to the channel of the user who issued the command. Upon success, the bot will announce itself within channel chat.
+
 ### Dad Mode
 Dual-side support for "Dad Mode" controls.  
 **Minimum Permission Level:** Moderator  

--- a/src/main/core/commands/Commands.java
+++ b/src/main/core/commands/Commands.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
 import main.core.Executor;
+import main.core.commands.commands.ComeHereCommand;
 import main.core.commands.commands.DadModeCommand;
 import main.core.commands.commands.IdleCheckerCommand;
 import main.core.commands.commands.KickCommand;
@@ -79,6 +80,10 @@ public class Commands {
       final String action = command[0].substring(1);
 
       switch (action.toLowerCase()) {
+         case "come":
+         case "comehere":
+            new ComeHereCommand(event);
+            return;
          case "dadmode":
             new DadModeCommand(event);
             return;

--- a/src/main/core/commands/commands/ComeHereCommand.java
+++ b/src/main/core/commands/commands/ComeHereCommand.java
@@ -1,0 +1,64 @@
+package main.core.commands.commands;
+
+import com.github.theholywaffle.teamspeak3.TS3ApiAsync;
+import com.github.theholywaffle.teamspeak3.api.event.TextMessageEvent;
+import com.github.theholywaffle.teamspeak3.api.wrapper.ClientInfo;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import main.conf.ConfigHandler;
+import main.core.Executor;
+import main.core.commands.AccessManager;
+import main.server.ServerConnectionManager;
+import main.util.MessageHandler;
+import main.util.Messages;
+import main.util.enums.AccessLevel;
+import main.util.exception.AuthorizationException;
+
+/**
+ * Command used to move the bot to the caller's channel.
+ */
+public class ComeHereCommand {
+
+   private TextMessageEvent event;
+   private TS3ApiAsync api;
+
+   /**
+    * Create a ComeHereCommand instance to handle client executions.
+    *
+    * @param event the {@link TextMessageEvent} that triggered the ComeHereCommand
+    * @throws AuthorizationException is the invoker of this command does not have authorization
+    * to execute it.
+    */
+   public ComeHereCommand(TextMessageEvent event) throws AuthorizationException {
+      this.event = event;
+      ServerConnectionManager instance = Executor.getServer("testInstance");
+      api = instance.getApiAsync();
+
+      AccessManager accessManager = new AccessManager(new ConfigHandler(), AccessLevel.DEFAULT);
+      AccessLevel invokerAccessLevel = accessManager.getAccessLevel(api.getClientInfo(event
+          .getInvokerId()).getUninterruptibly().getServerGroups());
+
+      try {
+         accessManager.checkAccess(invokerAccessLevel);
+         this.handle();
+      } catch (AuthorizationException e) {
+         throw new AuthorizationException(invokerAccessLevel, "!comehere");
+      }
+   }
+
+   private void handle() {
+      final String RETURN_TEXT = "You rang?";
+
+      try {
+         ClientInfo invoker = api.getClientInfo(event.getInvokerId()).get(2500, TimeUnit
+             .MILLISECONDS);
+         Integer channelId = invoker.getChannelId();
+
+         api.moveQuery(channelId);
+         new MessageHandler(RETURN_TEXT).sendToChannel();
+      } catch (InterruptedException | TimeoutException e) {
+         new MessageHandler(String.format(Messages.ERROR_COMMAND_TIMEOUT, "ComeHere"))
+             .returnToSender(event);
+      }
+   }
+}


### PR DESCRIPTION
# #53 - Create "ComeHere" Command  

## What was changed?  
Added support for "!comehere" text chat command.

## Why was it necessary?  
Allows bot users to summon the bot to their channel for easier communication.

## How was it tested?  
Manually in a private server by summoning the bot through server and private chat.