### PR TITLE
INCOBOT-13 - Create persistent storage for user information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ hs_err_pid*
 target/
 /.idea/
 /incobot-ts3.iml
+/db/

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,16 @@
   <artifactId>incobot-ts3</artifactId>
   <version>0.2.0-SNAPSHOT</version>
 
+  <repositories>
+    <repository>
+      <id>objectdb</id>
+      <name>ObjectDB Repository</name>
+      <url>http://m2.objectdb.com</url>
+    </repository>
+  </repositories>
+
   <build>
     <sourceDirectory>src</sourceDirectory>
-
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -43,7 +50,6 @@
   </build>
 
   <dependencies>
-
     <dependency>
       <groupId>com.github.theholywaffle</groupId>
       <artifactId>teamspeak3-api</artifactId>
@@ -70,6 +76,20 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.objectdb</groupId>
+      <artifactId>objectdb</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>javax.persistence</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
+    </dependency>
   </dependencies>
-
 </project>

--- a/src/main/data_access/DatabaseConnector.java
+++ b/src/main/data_access/DatabaseConnector.java
@@ -4,11 +4,20 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+/**
+ * Handles connections to the embedded database.
+ */
 public class DatabaseConnector {
    private static String USER_TABLE = "./db/users.odb";
    private EntityManagerFactory managerFactory;
    private EntityManager manager;
 
+   /**
+    * Generates an {@link EntityManager} for the given {@link Table}
+    *
+    * @param table the {@code Table} with which a connection should be established.
+    * @return an {@code EntityManager} that manages transactions to the provided {@code Table}.
+    */
    public EntityManager getEntityManager(Table table) {
       if (table == Table.USER) {
          this.managerFactory = Persistence.createEntityManagerFactory(USER_TABLE);
@@ -18,11 +27,17 @@ public class DatabaseConnector {
       return manager;
    }
 
+   /**
+    * Closes the connection this {@link DatabaseConnector} is utilizing.
+    */
    public void close() {
       manager.close();
       managerFactory.close();
    }
 
+   /**
+    * Existing database tables in use by this program.
+    */
    public enum Table {
       USER
    }

--- a/src/main/data_access/DatabaseConnector.java
+++ b/src/main/data_access/DatabaseConnector.java
@@ -1,0 +1,29 @@
+package main.data_access;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+public class DatabaseConnector {
+   private static String USER_TABLE = "./db/users.odb";
+   private EntityManagerFactory managerFactory;
+   private EntityManager manager;
+
+   public EntityManager getEntityManager(Table table) {
+      if (table == Table.USER) {
+         this.managerFactory = Persistence.createEntityManagerFactory(USER_TABLE);
+         this.manager = managerFactory.createEntityManager();
+      }
+
+      return manager;
+   }
+
+   public void close() {
+      manager.close();
+      managerFactory.close();
+   }
+
+   public enum Table {
+      USER
+   }
+}

--- a/src/main/data_access/models/User.java
+++ b/src/main/data_access/models/User.java
@@ -1,10 +1,9 @@
 package main.data_access.models;
 
 import com.github.theholywaffle.teamspeak3.api.wrapper.Client;
-import java.sql.Date;
+import com.github.theholywaffle.teamspeak3.api.wrapper.DatabaseClientInfo;
+import java.util.Date;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 /**
@@ -13,13 +12,10 @@ import javax.persistence.Id;
 @Entity
 public class User {
    //Persistent Fields
-   @Id @GeneratedValue(strategy = GenerationType.AUTO) private Integer id;
-   private Integer tsdbid;
+   @Id private Integer tsdbid;
    private String uid;
    private String name;
-   private Boolean isOnline;
    private Date createdAt;
-   private Date updatedAt;
    private Date lastSeen;
 
    /**
@@ -27,15 +23,15 @@ public class User {
     * @param tsDatabaseId the TeamSpeak database ID of the user,
     * retrieved by calling {@link Client#getDatabaseId()}
     */
-   User (Integer tsDatabaseId) {
+   public User (Integer tsDatabaseId) {
       this.tsdbid = tsDatabaseId;
    }
 
-   /**
-    * @return the unique identifier of this {@code User}.
-    */
-   public Integer getId() {
-      return id;
+   public User (DatabaseClientInfo dbClient) {
+      this.tsdbid = dbClient.getDatabaseId();
+      this.createdAt = dbClient.getCreatedDate();
+      this.lastSeen = dbClient.getLastConnectedDate();
+      this.name = dbClient.getNickname();
    }
 
    /**
@@ -74,20 +70,6 @@ public class User {
    }
 
    /**
-    * @return whether or not this {@code User} is online.
-    */
-   public Boolean getOnlineStatus() {
-      return isOnline;
-   }
-
-   /**
-    * @param online whether or not this {@code User} is online.
-    */
-   public void setOnline(Boolean online) {
-      isOnline = online;
-   }
-
-   /**
     * @return the date this {@code User} was first seen on this server.
     */
    public Date getCreatedAt() {
@@ -99,20 +81,6 @@ public class User {
     */
    public void setCreatedAt(Date createdAt) {
       this.createdAt = createdAt;
-   }
-
-   /**
-    * @return the date of the most recent update to this {@code User}.
-    */
-   public Date getUpdatedAt() {
-      return updatedAt;
-   }
-
-   /**
-    * @param updatedAt the date of the most recent update to this {@code User}.
-    */
-   public void setUpdatedAt(Date updatedAt) {
-      this.updatedAt = updatedAt;
    }
 
    /**

--- a/src/main/data_access/models/User.java
+++ b/src/main/data_access/models/User.java
@@ -1,0 +1,131 @@
+package main.data_access.models;
+
+import com.github.theholywaffle.teamspeak3.api.wrapper.Client;
+import java.sql.Date;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/**
+ * Data model class for TeamSpeak server users.
+ */
+@Entity
+public class User {
+   //Persistent Fields
+   @Id @GeneratedValue(strategy = GenerationType.AUTO) private Integer id;
+   private Integer tsdbid;
+   private String uid;
+   private String name;
+   private Boolean isOnline;
+   private Date createdAt;
+   private Date updatedAt;
+   private Date lastSeen;
+
+   /**
+    * Creates a new {@link User} with the provided TeamSpeak database ID.
+    * @param tsDatabaseId the TeamSpeak database ID of the user,
+    * retrieved by calling {@link Client#getDatabaseId()}
+    */
+   User (Integer tsDatabaseId) {
+      this.tsdbid = tsDatabaseId;
+   }
+
+   /**
+    * @return the unique identifier of this {@code User}.
+    */
+   public Integer getId() {
+      return id;
+   }
+
+   /**
+    * @return the unique identifier of this {@code User} in the TeamSpeak server's database.
+    */
+   public Integer getTsdbid() {
+      return tsdbid;
+   }
+
+   /**
+    * @return the unique ID of the TeamSpeak client.
+    */
+   public String getUid() {
+      return uid;
+   }
+
+   /**
+    * @param uid the unique ID of the TeamSpeak client.
+    */
+   public void setUid(String uid) {
+      this.uid = uid;
+   }
+
+   /**
+    * @return the nickname in use by this TeamSpeak client.
+    */
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * @param name the nickname in use by this TeamSpeak client.
+    */
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   /**
+    * @return whether or not this {@code User} is online.
+    */
+   public Boolean getOnlineStatus() {
+      return isOnline;
+   }
+
+   /**
+    * @param online whether or not this {@code User} is online.
+    */
+   public void setOnline(Boolean online) {
+      isOnline = online;
+   }
+
+   /**
+    * @return the date this {@code User} was first seen on this server.
+    */
+   public Date getCreatedAt() {
+      return createdAt;
+   }
+
+   /**
+    * @param createdAt the date this {@code User} was first seen on this server.
+    */
+   public void setCreatedAt(Date createdAt) {
+      this.createdAt = createdAt;
+   }
+
+   /**
+    * @return the date of the most recent update to this {@code User}.
+    */
+   public Date getUpdatedAt() {
+      return updatedAt;
+   }
+
+   /**
+    * @param updatedAt the date of the most recent update to this {@code User}.
+    */
+   public void setUpdatedAt(Date updatedAt) {
+      this.updatedAt = updatedAt;
+   }
+
+   /**
+    * @return the date this {@code User} last connected to the server.
+    */
+   public Date getLastSeen() {
+      return lastSeen;
+   }
+
+   /**
+    * @param lastSeen the date this {@code User} last connected to the server.
+    */
+   public void setLastSeen(Date lastSeen) {
+      this.lastSeen = lastSeen;
+   }
+}

--- a/src/main/server/listeners/handlers/ClientJoinHandler.java
+++ b/src/main/server/listeners/handlers/ClientJoinHandler.java
@@ -4,6 +4,7 @@ import com.github.theholywaffle.teamspeak3.TS3Api;
 import com.github.theholywaffle.teamspeak3.api.event.ClientJoinEvent;
 import com.github.theholywaffle.teamspeak3.api.wrapper.Client;
 import com.github.theholywaffle.teamspeak3.api.wrapper.ClientInfo;
+import com.github.theholywaffle.teamspeak3.api.wrapper.DatabaseClientInfo;
 import com.github.theholywaffle.teamspeak3.api.wrapper.ServerGroup;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -12,8 +13,15 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
 import main.core.Config;
 import main.core.Executor;
+import main.data_access.DatabaseConnector;
+import main.data_access.DatabaseConnector.Table;
+import main.data_access.models.User;
 import main.util.LogPrefix;
 import main.util.MessageHandler;
 import main.util.Messages;
@@ -60,6 +68,7 @@ public class ClientJoinHandler {
       }
 
       checkMembership();
+      updateDatabase();
    }
 
    private void logToFile() {
@@ -91,6 +100,33 @@ public class ClientJoinHandler {
       } catch (IOException e) {
          e.printStackTrace();
       }
+   }
+
+   private void updateDatabase() {
+      //Create connection
+      DatabaseConnector connector = new DatabaseConnector();
+      EntityManager em = connector.getEntityManager(Table.USER);
+
+      //Check to see if user exists already
+      User user = em.find(User.class, event.getClientDatabaseId());
+
+      if (user != null) {
+         //Update User
+         em.getTransaction().begin();
+         user.setLastSeen(api.getHostInfo().getTimeStamp());
+         em.getTransaction().commit();
+      } else {
+         //Create User
+         user = new User(api.getDatabaseClientInfo(event.getClientDatabaseId()));
+         user.setUid(event.getUniqueClientIdentifier());
+         user.setLastSeen(api.getHostInfo().getTimeStamp());
+
+         em.getTransaction().begin();
+         em.persist(user);
+         em.getTransaction().commit();
+      }
+
+      connector.close();
    }
 
    /**


### PR DESCRIPTION
# INCOBOT-13 - Create persistent storage for user information

## What was changed?  
Added database to store User objects.
Added update logic for User objects when clients connect or disconnect.  
  
## Why was it necessary?  
Allows persistence of user information not available on the teamspeak server when the client is not online.

## How was it tested?  
Manually on a local test server by connecting and ensuring the data was in the database.
