### PR TITLE
INCOBOT-21 - Handle Errors Gracefully

### DIFF
--- a/src/main/conf/ConfigHandler.java
+++ b/src/main/conf/ConfigHandler.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Level;
+import main.util.MessageHandler;
 
 /**
  * Utility class for managing reading from and writing to configuration files.
@@ -23,7 +25,8 @@ public class ConfigHandler {
       try {
          return mapper.readValue(file, ConnectionConfiguration.class);
       } catch (IOException e) {
-         e.printStackTrace();
+         new MessageHandler("Could not read file: \"/config/ConnectionConfig.yaml\"")
+             .sendToConsoleWith(Level.SEVERE);
          return null;
       }
    }
@@ -41,7 +44,8 @@ public class ConfigHandler {
       try {
          return mapper.readValue(file, IdleCheckConfiguration.class);
       } catch (IOException e) {
-         e.printStackTrace();
+         new MessageHandler("Could not read file: \"/config/IdleChecker.yaml\"")
+             .sendToConsoleWith(Level.SEVERE);
          return null;
       }
    }
@@ -59,7 +63,8 @@ public class ConfigHandler {
       try {
          return mapper.readValue(file, ServerGroupAccessConfiguration.class);
       } catch (IOException e) {
-         e.printStackTrace();
+         new MessageHandler("Could not read file: \"/config/ServerGroupAccess.yaml\"")
+             .sendToConsoleWith(Level.SEVERE);
          return null;
       }
    }

--- a/src/main/server/ServerConnectionManager.java
+++ b/src/main/server/ServerConnectionManager.java
@@ -171,10 +171,11 @@ public class ServerConnectionManager {
    }
 
    public void printUserList() { //TODO Refactor to be viable, likely as part of clientinfo command.
+      StringBuilder builder = new StringBuilder("Online Users: \n");
       for (ClientInfo client : connectedUserList.values()) {
-         System.out.println(
-             client.getId() + " : " + client.getNickname() + " : " + client.getUniqueIdentifier());
+         builder.append(client.toString() + "\n");
       }
+      new MessageHandler(builder.toString()).sendToConsoleWith(Level.INFO);
    }
 
    private void compileOnlineUserList(TS3Api api) {


### PR DESCRIPTION
# INCOBOT-21 - Handle Errors Gracefully

## What was changed?  
Removed stacktrace prints. All errors should now be sent through the message handler except for unhandled exceptions passed to the top of the program.

## Why was it necessary?  
Consistency and to ensure users receive helpful error messages wherever possible.

## How was it tested?  
It wasn't.
